### PR TITLE
Bitte lesen: LowMiddleHigh

### DIFF
--- a/DynamicAnalyzer/src/analyzer/level1/JimpleInjector.java
+++ b/DynamicAnalyzer/src/analyzer/level1/JimpleInjector.java
@@ -432,58 +432,89 @@ public class JimpleInjector {
 	 * Change level of elements
 	 */
 	
-	/**
-	 * Set the security-level of a local to HIGH.
-	 * @param local Local
-	 * @param pos Unit where this local occurs
-	 */
-	public static void makeLocalHigh(Local local, Unit pos) {
-		logger.log(Level.INFO, "Make Local {0} high in method {1}",
-			new Object[] {getSignatureForLocal(local), b.getMethod().getName()});
-		
-		ArrayList<Type> paramTypes = new ArrayList<Type>();
-		paramTypes.add(RefType.v("java.lang.String"));
-		
-		String signature = getSignatureForLocal(local);
-		Stmt sig = Jimple.v().newAssignStmt(local_for_Strings, StringConstant.v(signature));
-		
-		Expr invokeAddLocal = Jimple.v().newVirtualInvokeExpr(
-				hs, Scene.v().makeMethodRef(Scene.v().getSootClass(HANDLE_CLASS), 
-				"makeLocalHigh", paramTypes, VoidType.v(),false),
-				local_for_Strings);
-		Unit ass = Jimple.v().newInvokeStmt(invokeAddLocal);
-		
-
-		unitStore_After.insertElement(unitStore_After.new Element(sig, pos));
-		unitStore_After.insertElement(unitStore_After.new Element(ass, sig));
-		lastPos = ass;
-	}
+//	/**
+//	 * Set the security-level of a local to HIGH.
+//	 * @param local Local
+//	 * @param pos Unit where this local occurs
+//	 */
+//	public static void makeLocalHigh(Local local, Unit pos) {
+//		logger.log(Level.INFO, "Make Local {0} high in method {1}",
+//			new Object[] {getSignatureForLocal(local), b.getMethod().getName()});
+//		
+//		ArrayList<Type> paramTypes = new ArrayList<Type>();
+//		paramTypes.add(RefType.v("java.lang.String"));
+//		
+//		String signature = getSignatureForLocal(local);
+//		Stmt sig = Jimple.v().newAssignStmt(local_for_Strings, StringConstant.v(signature));
+//		
+//		Expr invokeAddLocal = Jimple.v().newVirtualInvokeExpr(
+//				hs, Scene.v().makeMethodRef(Scene.v().getSootClass(HANDLE_CLASS), 
+//				"makeLocalHigh", paramTypes, VoidType.v(),false),
+//				local_for_Strings);
+//		Unit ass = Jimple.v().newInvokeStmt(invokeAddLocal);
+//		
+//
+//		unitStore_After.insertElement(unitStore_After.new Element(sig, pos));
+//		unitStore_After.insertElement(unitStore_After.new Element(ass, sig));
+//		lastPos = ass;
+//	}
 	
 	/**
-	 * Set the security-level of a local to LOW.
-	 * @param local Local
-	 * @param pos Unit where this local occurs
+	 * Include a new handlestatement.setLevelOfLocal(local, level)
+	 * @param local
+	 * @param level
+	 * @param pos
 	 */
-	public static void makeLocalLow(Local local, Unit pos) {
-		logger.log(Level.INFO, "Make Local {0} low in method {1}",
-			new Object[] {getSignatureForLocal(local), b.getMethod().getName()});
+	public static void makeLocal(Local local, String level, Unit pos) {
+		logger.info("Setting " + local + "to new level " + level );
 		
 		ArrayList<Type> paramTypes = new ArrayList<Type>();
 		paramTypes.add(RefType.v("java.lang.String"));
+		paramTypes.add(RefType.v("java.lang.String"));
 		
+		// local_for_Strings = getSignatureForLocal(local)
 		String signature = getSignatureForLocal(local);
 		Stmt sig = Jimple.v().newAssignStmt(local_for_Strings, StringConstant.v(signature));
 		
-		Expr invokeAddLocal = Jimple.v().newVirtualInvokeExpr(
-				hs, Scene.v().makeMethodRef(Scene.v().getSootClass(HANDLE_CLASS), 
-				"makeLocalLow", paramTypes, VoidType.v(),false), local_for_Strings);
-		Unit ass = Jimple.v().newInvokeStmt(invokeAddLocal);
+		// makeLocal(local_for_Strings, "HIHG", position);
+		Expr invokeSetLevel = Jimple.v().newVirtualInvokeExpr(
+				hs, 
+				Scene.v().makeMethodRef(Scene.v().getSootClass(HANDLE_CLASS), 
+				"makeLocal", paramTypes, 
+				VoidType.v(),	false), 
+				local_for_Strings, StringConstant.v(level));
+		Unit setLevelOfL = Jimple.v().newInvokeStmt(invokeSetLevel);
 		
-
 		unitStore_After.insertElement(unitStore_After.new Element(sig, pos));
-		unitStore_After.insertElement(unitStore_After.new Element(ass, sig));
-		lastPos = ass;
+		unitStore_After.insertElement(unitStore_After.new Element(setLevelOfL, sig));
+		lastPos = setLevelOfL;
 	}
+	
+//	/**
+//	 * Set the security-level of a local to LOW.
+//	 * @param local Local
+//	 * @param pos Unit where this local occurs
+//	 */
+//	public static void makeLocalLow(Local local, Unit pos) {
+//		logger.log(Level.INFO, "Make Local {0} low in method {1}",
+//			new Object[] {getSignatureForLocal(local), b.getMethod().getName()});
+//		
+//		ArrayList<Type> paramTypes = new ArrayList<Type>();
+//		paramTypes.add(RefType.v("java.lang.String"));
+//		
+//		String signature = getSignatureForLocal(local);
+//		Stmt sig = Jimple.v().newAssignStmt(local_for_Strings, StringConstant.v(signature));
+//		
+//		Expr invokeAddLocal = Jimple.v().newVirtualInvokeExpr(
+//				hs, Scene.v().makeMethodRef(Scene.v().getSootClass(HANDLE_CLASS), 
+//				"makeLocalLow", paramTypes, VoidType.v(),false), local_for_Strings);
+//		Unit ass = Jimple.v().newInvokeStmt(invokeAddLocal);
+//		
+//
+//		unitStore_After.insertElement(unitStore_After.new Element(sig, pos));
+//		unitStore_After.insertElement(unitStore_After.new Element(ass, sig));
+//		lastPos = ass;
+//	}
 
 	/**
 	 * Add the level of a local on the right side of an assign statement.
@@ -930,6 +961,8 @@ public class JimpleInjector {
 		unitStore_After.insertElement(unitStore_After.new Element(assignExpr, lastPos));
 		lastPos = assignExpr;
 	}
+	
+	
 	
 	/*******************************************************************************************
 	 *	Inter-scope functions.

--- a/DynamicAnalyzer/src/analyzer/level1/JimpleInjector.java
+++ b/DynamicAnalyzer/src/analyzer/level1/JimpleInjector.java
@@ -1075,7 +1075,7 @@ public class JimpleInjector {
 	 * @param pos
 	 * @param l
 	 */
-	public static void checkThatNotHigh(Unit pos, Local l) {
+	public static void checkThatNot(Local l, String level, Unit pos) {
 		logger.info("Check that " + l + " is not high");
 		
 		if (l == null)	{
@@ -1083,6 +1083,7 @@ public class JimpleInjector {
 		}
 		
 		ArrayList<Type> paramTypes = new ArrayList<Type>();
+		paramTypes.add(RefType.v("java.lang.String"));
 		paramTypes.add(RefType.v("java.lang.String"));
 		
 		String signature = getSignatureForLocal(l);
@@ -1092,8 +1093,8 @@ public class JimpleInjector {
 		
 		Expr invokeSetLevel = Jimple.v().newVirtualInvokeExpr(
 				hs, Scene.v().makeMethodRef(Scene.v().getSootClass(HANDLE_CLASS), 
-				"checkThatNotHigh", paramTypes, VoidType.v(),	false), 
-				local_for_Strings);
+				"checkThatNot", paramTypes, VoidType.v(),	false), 
+				local_for_Strings, StringConstant.v(level));
 		Unit invoke = Jimple.v().newInvokeStmt(invokeSetLevel);
 		
 

--- a/DynamicAnalyzer/src/analyzer/level1/JimpleInjector.java
+++ b/DynamicAnalyzer/src/analyzer/level1/JimpleInjector.java
@@ -1103,20 +1103,24 @@ public class JimpleInjector {
 	}
 	
 	/**
-	 * Method to check that PC is not high. Called when calling System.out.println(), 
+	 * Method to check that PC is not of specified level, or above. Called when calling System.out.println(), 
 	 * which must always be called in low context because of its side effects.
+	 * @param level 	level that the PC must not exceed
 	 * @param pos
 	 */
-	public static void checkThatPCNotHigh(Unit pos) {
-		logger.info("Check that context is not high");
+	public static void checkThatPCLessThan(String level, Unit pos) {
+		logger.info("Check that context is not " + level + "or above");
 		
 		if (pos == null) {
 			throw new InternalAnalyzerException("Position is Null");
 		}
 		
+		ArrayList<Type> paramTypes = new ArrayList<Type>();
+		paramTypes.add(RefType.v("java.lang.String"));
+		
 		Expr checkPC = Jimple.v().newVirtualInvokeExpr(
 				hs, Scene.v().makeMethodRef(Scene.v().getSootClass(HANDLE_CLASS),
-						"checkThatPCNotHigh", new ArrayList<Type>(), VoidType.v(), false));
+						"checkThatPCLessThan", paramTypes, VoidType.v(), false), StringConstant.v(level));
 		Unit invoke = Jimple.v().newInvokeStmt(checkPC);
 		
 		unitStore_Before.insertElement(unitStore_Before.new Element(invoke, pos));

--- a/DynamicAnalyzer/src/analyzer/level2/HandleStmt.java
+++ b/DynamicAnalyzer/src/analyzer/level2/HandleStmt.java
@@ -807,11 +807,11 @@ public class HandleStmt {
 	 * @param signature
 	 *            signature of the argument
 	 */
-	public void checkThatNotHigh(String signature) {
+	public void checkThatNot(String signature, String level) {
 		logger.info("Check that " + localmap.getLevel(signature)
-				+ " is not HIGH");
-		if (localmap.getLevel(signature) == SecurityLevel.top()) {
-			logger.info("it's high");
+				+ " is not " + level + " or higher");
+		if (!SecurityLevel.lt(localmap.getLevel(signature), SecurityLevel.readLevel(level))) {
+			logger.info("it's " + SecurityLevel.readLevel(level));
 			handleStatementUtils.abort("Passed argument " + signature
 					+ " with a high security level to a method "
 					+ "which doesn't allow it.");

--- a/DynamicAnalyzer/src/analyzer/level2/HandleStmt.java
+++ b/DynamicAnalyzer/src/analyzer/level2/HandleStmt.java
@@ -295,7 +295,7 @@ public class HandleStmt {
 		logger.info("Set level of local " + signature + " to " + level);
 		handleStatementUtils.checkIfLocalExists(signature);
 		localmap.initializeLocal(signature);
-		localmap.setLevel(signature, SecurityLevel.redSecLevel(level));
+		localmap.setLevel(signature, SecurityLevel.readLevel(level));
 		logger.info("New securitylevel of local " + signature + " is "
 				+ localmap.getLevel(signature));
 	}
@@ -822,13 +822,14 @@ public class HandleStmt {
 	 * This method is used if a print statement is identified. Print statements
 	 * must never be called in high sec context. Thus, we must check the
 	 * context;
+	 * @param level TODO
 	 */
-	public void checkThatPCNotHigh() {
-		logger.info("About to print something to public output. Thus, check that PC is not HIGH");
-		if (localmap.getLocalPC() == SecurityLevel.top()) {
-			logger.info("Trying to print with HIGH PC!");
+	public void checkThatPCLessThan(String level) {
+		logger.info("About to print something somewhere. Requires to check that PC is less than " + level);
+		if (!SecurityLevel.lt(localmap.getLocalPC(), SecurityLevel.readLevel(level))) {
+			logger.info("Trying to print with "+ level + " PC!");
 			handleStatementUtils
-					.abort("Tried to print in high-security context: LocalPC was HIGH!");
+					.abort("Tried to print in high-security context: LocalPC was " + level + "!");
 		}
 	}
 }

--- a/DynamicAnalyzer/src/analyzer/level2/HandleStmt.java
+++ b/DynamicAnalyzer/src/analyzer/level2/HandleStmt.java
@@ -290,35 +290,50 @@ public class HandleStmt {
 		localmap.initializeLocal(signature);
 		return localmap.getLevel(signature);
 	}
-
-	/**
-	 * Set SecurityLevel of given local to HIGH.
-	 * 
-	 * @param signature
-	 *            signature of local
-	 */
-	public void makeLocalHigh(String signature) {
-		logger.info("Set level of local " + signature
-				+ " to SecurityLevel.top()");
+	
+	public void makeLocal(String signature, String level) {
+		logger.info("Set level of local " + signature + " to " + level);
 		handleStatementUtils.checkIfLocalExists(signature);
 		localmap.initializeLocal(signature);
-		localmap.setLevel(signature, SecurityLevel.top());
+		localmap.setLevel(signature, SecurityLevel.redSecLevel(level));
 		logger.info("New securitylevel of local " + signature + " is "
 				+ localmap.getLevel(signature));
 	}
-
-	/**
-	 * Set SecurityLevel of given local to LOW.
-	 * 
-	 * @param signature
-	 *            signature of local
-	 */
-	public void makeLocalLow(String signature) {
-		logger.info("Set level of " + signature + " to SecurityLevel.bottom()");
-		handleStatementUtils.checkIfLocalExists(signature);
-		localmap.setLevel(signature, SecurityLevel.bottom());
-		logger.info("New securitylevel: " + localmap.getLevel(signature));
-	}
+	
+	
+//	
+//
+//	/**
+//	 * Set SecurityLevel of given local to HIGH. This one is
+//	 * actually in use (by the AnnotationSwitchStmt)
+//	 * 
+//	 * @param signature
+//	 *            signature of local
+//	 */
+//	public void makeLocalHigh(String signature) {
+//		logger.info("Set level of local " + signature
+//				+ " to SecurityLevel.top()");
+//		handleStatementUtils.checkIfLocalExists(signature);
+//		localmap.initializeLocal(signature);
+//		localmap.setLevel(signature, SecurityLevel.top());
+//		logger.info("New securitylevel of local " + signature + " is "
+//				+ localmap.getLevel(signature));
+//	}
+//
+//	/**
+//	 * Set SecurityLevel of given local to LOW. This one is
+//	 * actually in use (by the AnnotationSwitchStmt).
+//	 * Same as above probably.
+//	 * 
+//	 * @param signature
+//	 *            signature of local
+//	 */
+//	public void makeLocalLow(String signature) {
+//		logger.info("Set level of " + signature + " to SecurityLevel.bottom()");
+//		handleStatementUtils.checkIfLocalExists(signature);
+//		localmap.setLevel(signature, SecurityLevel.bottom());
+//		logger.info("New securitylevel: " + localmap.getLevel(signature));
+//	}
 
 	/**
 	 * Push the level of a given instance to the globalPC (e.g. on top of its stack)
@@ -589,9 +604,10 @@ public class HandleStmt {
 	 *            security-level
 	 * @return The new security-level
 	 */
-	protected Object setLevelOfLocal(String signature, Object securitylevel) {
+	public Object setLevelOfLocal(String signature, Object securitylevel) {
 		logger.log(Level.INFO, "Set level of local {0} to {1}", new Object[] {
 				signature, securitylevel });
+		handleStatementUtils.checkIfLocalExists(signature);
 		localmap.initializeLocal(signature);
 		localmap.setLevel(signature, securitylevel);
 		return localmap.getLevel(signature);

--- a/DynamicAnalyzer/src/analyzer/level2/SecurityLevel.java
+++ b/DynamicAnalyzer/src/analyzer/level2/SecurityLevel.java
@@ -13,12 +13,13 @@ package analyzer.level2;
 //}
 
 import analyzer.level2.storage.LowHigh;
+import analyzer.level2.storage.LowMediumHigh;
 import de.unifreiburg.cs.proglang.jgs.constraints.SecDomain;
 
 
 public class SecurityLevel {
 	@SuppressWarnings("rawtypes")
-	public static SecDomain secDomain = new LowHigh();
+	public static SecDomain secDomain = new LowMediumHigh();
 	
 	public static Object bottom() {
 		return secDomain.bottom();

--- a/DynamicAnalyzer/src/analyzer/level2/SecurityLevel.java
+++ b/DynamicAnalyzer/src/analyzer/level2/SecurityLevel.java
@@ -42,4 +42,8 @@ public class SecurityLevel {
 	public static boolean le(Object l1, Object l2) {
 		return secDomain.le(l1, l2);
 	}
+	
+	public static Object redSecLevel(String level) {
+		return secDomain.readLevel(level);
+	}
 }

--- a/DynamicAnalyzer/src/analyzer/level2/SecurityLevel.java
+++ b/DynamicAnalyzer/src/analyzer/level2/SecurityLevel.java
@@ -44,7 +44,18 @@ public class SecurityLevel {
 		return secDomain.le(l1, l2);
 	}
 	
-	public static Object redSecLevel(String level) {
+	/**
+	 * Strictly less than
+	 * @param l1
+	 * @param l2
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	public static boolean lt(Object l1, Object l2) {
+		return secDomain.le(l1, l2) && !l1.equals(l2);
+	}
+	
+	public static Object readLevel(String level) {
 		return secDomain.readLevel(level);
 	}
 }

--- a/DynamicAnalyzer/src/analyzer/level2/storage/LowHigh.java
+++ b/DynamicAnalyzer/src/analyzer/level2/storage/LowHigh.java
@@ -6,7 +6,7 @@ import de.unifreiburg.cs.proglang.jgs.signatures.parse.AnnotationParser;
 import java.util.Arrays;
 import java.util.Iterator;
 
-public class LowHigh extends SecDomain<LowHigh.Level> {
+public class LowHigh extends SecDomain<LowHigh.Level> {	// like: SecDomain ist die Relation; LowHigh.Level die "Menge"
     
 	public static enum Level {
         LOW, HIGH
@@ -39,19 +39,30 @@ public class LowHigh extends SecDomain<LowHigh.Level> {
 
 	@Override
     public AnnotationParser<Level> levelParser() {
-//        return new AnnotationParser<Level>() {
-//            @Override
-//            public Option<Level> parse(String s) {
-//            if (s.equals("LOW")) {
-//               return Option.apply(Level.LOW);
-//            } else if (s.equals("HIGH")) {
-//                return Option.apply(Level.HIGH);
-//            } else {
-//                return Option.empty();
-//            }
-//            }
-//		  };
+  /*      return new AnnotationParser<Level>() {
+            @Override
+            public Option<Level> parse(String s) {
+            if (s.equals("LOW")) {
+               return Option.apply(Level.LOW);
+            } else if (s.equals("HIGH")) {
+                return Option.apply(Level.HIGH);
+            } else {
+                return Option.empty();
+            }
+            }
+		  }; */
 		return null;
+	}
+	
+	@Override
+	public Level readLevel(String s) {
+		if (s.equals("LOW")) {
+            return Level.LOW;
+         } else if (s.equals("HIGH")) {
+             return Level.HIGH;
+         } else {
+	         throw new IllegalArgumentException(String.format("Error parsing string %s to a level", s));
+         }
 	}
 
 	@Override

--- a/DynamicAnalyzer/src/analyzer/level2/storage/LowMediumHigh.java
+++ b/DynamicAnalyzer/src/analyzer/level2/storage/LowMediumHigh.java
@@ -1,0 +1,90 @@
+package analyzer.level2.storage;
+
+import de.unifreiburg.cs.proglang.jgs.constraints.SecDomain;
+import de.unifreiburg.cs.proglang.jgs.signatures.parse.AnnotationParser;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import utils.exceptions.InternalAnalyzerException;
+
+public class LowMediumHigh extends SecDomain<LowMediumHigh.Level> { 
+
+	public static enum Level {
+		LOW, MEDIUM, HIGH
+	}
+
+	@Override
+	public Level bottom() {
+		return Level.LOW;
+	}
+
+	@Override
+	public Level top() {
+		return Level.HIGH;
+	}
+
+	@Override
+	public Level lub(Level l1, Level l2) {
+		return le(l1, l2) ? l2 : l1; // because LOW-MEDIUM-HIGH has total
+										// ordering
+	}
+
+	@Override
+	public Level glb(Level l1, Level l2) {
+		return le(l1, l2) ? l1 : l2;
+	}
+
+	@Override
+	public boolean le(Level l1, Level l2) {
+		switch (l1) {
+		case HIGH:
+			return l2.equals(Level.HIGH) ? true : false; // if l1 == HIGH, then
+															// l2 needs to be
+															// HIGH to return
+															// true
+		case MEDIUM:
+			if (l2.equals(Level.LOW)) {
+				return false; // l1 == MEDIUM, l2 == LOW
+			} else {
+				return true; // l1 == MEDIUM, l2 == MEDIUM or HIGH
+			}
+		case LOW:
+			return true;
+		default:
+			throw new InternalAnalyzerException("Weird level: " + l1);
+		}
+	}
+
+	@Override
+	public AnnotationParser<Level> levelParser() {
+		/*
+		 * return new AnnotationParser<Level>() {
+		 * 
+		 * @Override public Option<Level> parse(String s) { if (s.equals("LOW"))
+		 * { return Option.apply(Level.LOW); } else if (s.equals("HIGH")) {
+		 * return Option.apply(Level.HIGH); } else { return Option.empty(); } }
+		 * };
+		 */
+		return null;
+	}
+
+	@Override
+	public Level readLevel(String s) {
+		if (s.equals("LOW")) {
+			return Level.LOW;
+		} else if (s.equals("MEDIUM")) {
+			return Level.MEDIUM;
+		} else if (s.equals("HIGH")) {
+			return Level.HIGH;
+		} else {
+			throw new IllegalArgumentException(String.format(
+					"Error parsing string %s to a level", s));
+		}
+	}
+
+	@Override
+	public Iterator<Level> enumerate() {
+		return Arrays.asList(Level.values()).iterator();
+	}
+}

--- a/DynamicAnalyzer/src/main/testclasses/PrintMediumFail.java
+++ b/DynamicAnalyzer/src/main/testclasses/PrintMediumFail.java
@@ -1,0 +1,12 @@
+package main.testclasses;
+
+import utils.analyzer.HelperClass;
+import utils.printer.SecurePrinter;
+
+public class PrintMediumFail {
+	public static void main(String[] args) {
+		String med = "This is medium information";
+		med = HelperClass.makeMedium(med);
+		System.out.println(med);
+	}
+}

--- a/DynamicAnalyzer/src/main/testclasses/PrintMediumFail.java
+++ b/DynamicAnalyzer/src/main/testclasses/PrintMediumFail.java
@@ -1,7 +1,6 @@
 package main.testclasses;
 
 import utils.analyzer.HelperClass;
-import utils.printer.SecurePrinter;
 
 public class PrintMediumFail {
 	public static void main(String[] args) {

--- a/DynamicAnalyzer/src/main/testclasses/PrintMediumFail2.java
+++ b/DynamicAnalyzer/src/main/testclasses/PrintMediumFail2.java
@@ -1,0 +1,12 @@
+package main.testclasses;
+
+import utils.analyzer.HelperClass;
+import utils.printer.SecurePrinter;
+
+public class PrintMediumFail2 {
+	public static void main(String[] args) {
+		String hi = "This is high information";
+		hi = HelperClass.makeHigh(hi);
+		SecurePrinter.printMedium(hi);
+	}
+}

--- a/DynamicAnalyzer/src/main/testclasses/PrintMediumSuccess.java
+++ b/DynamicAnalyzer/src/main/testclasses/PrintMediumSuccess.java
@@ -1,0 +1,16 @@
+package main.testclasses;
+
+import utils.analyzer.HelperClass;
+import utils.printer.SecurePrinter;
+
+public class PrintMediumSuccess {
+	public static void main(String[] args) {
+		String med = "This is medium information";
+		med = HelperClass.makeMedium(med);
+		SecurePrinter.printMedium(med);
+		
+		String low = "This is low information";
+		low = HelperClass.makeLow(low);
+		SecurePrinter.printMedium(low);
+	}
+}

--- a/DynamicAnalyzer/src/utils/analyzer/HelperClass.java
+++ b/DynamicAnalyzer/src/utils/analyzer/HelperClass.java
@@ -5,13 +5,17 @@ package utils.analyzer;
  * Note that the return value must be assigned to the original value,
  * otherwise the security-level won't be assigned to the original field.
  * 
- * This method itself does not do much, but its existence allows the jimple
+ * This method itself does not do anything, but its existence allows the jimple
  * injector to inject appropriate code.
  * @author koenigr
  */
 public class HelperClass {
 
 	public static <T> T makeHigh(T value) {
+		return value;
+	}
+	
+	public static <T> T makeMedium(T value) {
 		return value;
 	}
 	

--- a/DynamicAnalyzer/src/utils/printer/SecurePrinter.java
+++ b/DynamicAnalyzer/src/utils/printer/SecurePrinter.java
@@ -1,0 +1,7 @@
+package utils.printer;
+
+public class SecurePrinter {
+	public static <T> void printMedium (T out) {
+		System.err.println(out);		// So that System.out.println wont trigger
+	}
+}

--- a/DynamicAnalyzer/src/utils/visitor/AnnotationStmtSwitch.java
+++ b/DynamicAnalyzer/src/utils/visitor/AnnotationStmtSwitch.java
@@ -2,6 +2,7 @@ package utils.visitor;
 
 import analyzer.level1.JimpleInjector;
 import analyzer.level1.storage.UnitStore.Element;
+import analyzer.level2.SecurityLevel;
 import soot.Body;
 import soot.Local;
 import soot.Value;
@@ -130,11 +131,16 @@ public class AnnotationStmtSwitch implements StmtSwitch {
 		switch (AnnotationValueSwitch.rightElement) {
 		case MAKE_HIGH:
 			logger.finest("Make left operand high");
-			JimpleInjector.makeLocalHigh((Local) leftOperand, aStmt);
+			JimpleInjector.makeLocal((Local) leftOperand, "HIGH", aStmt);
+			// JimpleInjector.makeLocalHigh((Local) leftOperand, aStmt);
 			break;
+		case MAKE_MEDIUM:
+			logger.finest("Make left operand medium");
+			JimpleInjector.makeLocal((Local) leftOperand, "MEDIUM", aStmt);
 		case MAKE_LOW:
 			logger.finest("Make left operand low");
-			JimpleInjector.makeLocalLow((Local) leftOperand, aStmt);
+			// JimpleInjector.makeLocalLow((Local) leftOperand, aStmt);
+			JimpleInjector.makeLocal((Local) leftOperand, "LOW", aStmt);
 			break;
 		case SET_RETURN_LEVEL:
 			JimpleInjector.setReturnLevelAfterInvokeStmt(leftOperand.toString(), aStmt);

--- a/DynamicAnalyzer/src/utils/visitor/AnnotationValueSwitch.java
+++ b/DynamicAnalyzer/src/utils/visitor/AnnotationValueSwitch.java
@@ -102,7 +102,7 @@ public class AnnotationValueSwitch implements JimpleValueSwitch {
 		NOT, NEW_ARRAY, NEW_UNDEF_OBJECT,
 		INVOKE_INTERAL_METHOD, INVOKE_EXTERNAL_METHOD, 
 		SET_RETURN_LEVEL,
-		MAKE_HIGH, MAKE_LOW
+		MAKE_HIGH, MAKE_MEDIUM, MAKE_LOW
 	} 
 	
 	protected static RightElement rightElement = RightElement.NOT;

--- a/DynamicAnalyzer/src/utils/visitor/ExternalClasses.java
+++ b/DynamicAnalyzer/src/utils/visitor/ExternalClasses.java
@@ -34,19 +34,23 @@ public class ExternalClasses {
 		
 		// Methods where the argument cannot have a High argument
 		methodMap.put("<java.io.PrintStream: void println(java.lang.String)>", 
-				 new NoHighAllowedForPrintOutput());
+				 new NotAllowedForPrintOutput("MEDIUM"));
 		methodMap.put("<java.io.PrintStream: void println(int)>", 
-				 new NoHighAllowedForPrintOutput());
+				 new NotAllowedForPrintOutput("MEDIUM"));
 		methodMap.put("<java.io.PrintStream: void println(boolean)>", 
-				 new NoHighAllowedForPrintOutput());
+				 new NotAllowedForPrintOutput("MEDIUM"));
 		methodMap.put("<java.io.PrintStream: void println(java.lang.Object)>", 
-				 new NoHighAllowedForPrintOutput());
+				 new NotAllowedForPrintOutput("MEDIUM"));
+		
+		// Methods 
 		
 		// Methods where we don't do anything
 		methodMap.put("<java.lang.Object: void <init>()>", new DoNothing());
 		
 		methodMap.put("<utils.analyzer.HelperClass: java.lang.Object "
 				+ "makeHigh(java.lang.Object)>", new MakeHigh());
+		methodMap.put("<utils.analyzer.HelperClass: java.lang.Object "
+				+ "makeMedium(java.lang.Object)>", new MakeMedium());
 		methodMap.put("<utils.analyzer.HelperClass: java.lang.Object "
 				+ "makeLow(java.lang.Object)>", new MakeLow());
 	}
@@ -71,27 +75,33 @@ public class ExternalClasses {
 		}
 	}
 	
-	static class NoHighAllowedForPrintOutput implements Command {
+	static class NotAllowedForPrintOutput implements Command {
+		
+		private String level;
+		public NotAllowedForPrintOutput(String level) {
+			this.level = level;
+		}
+		
 		public void execute(Unit pos, Local[] params) {
-			logger.fine("Insert check that external class has no high argument");
+			logger.fine("Insert check that external class has no " + level + " arguments");
 			if (params == null || pos == null) {
 				throw new InternalAnalyzerException(
 						"Received a null-pointer as argument");
 			}
 			
 			// If print Statement is called, context must not be high: This, we can always check
-			JimpleInjector.checkThatPCLessThan("HIGH", pos);
+			JimpleInjector.checkThatPCLessThan(level, pos);
 			
 			// Also, we might print in low context: If so, we mustn't print a high-sec param
 			for (Local param: params) {
 				if (param != null) {
-					JimpleInjector.checkThatNot(param, "HIGH", pos);
+					JimpleInjector.checkThatNot(param, level, pos);
 					
 				}
 			} 
 		}
 	}
-
+	
 	static class DoNothing implements Command	{
 		@Override
 		public void execute(Unit pos, Local[] params) {
@@ -107,6 +117,14 @@ public class ExternalClasses {
 			logger.fine("Variable" + params[0].toString() + " is set to high");
 			JimpleInjector.makeLocalHigh(params[0], pos);*/
 			AnnotationValueSwitch.rightElement = RightElement.MAKE_HIGH;
+		}
+	}
+	
+	static class MakeMedium implements Command {
+		@Override
+		public void execute(Unit pos, Local[] params) {
+			logger.info("Right element is a makeMedium method");
+			AnnotationValueSwitch.rightElement = RightElement.MAKE_MEDIUM;
 		}
 	}
 	

--- a/DynamicAnalyzer/src/utils/visitor/ExternalClasses.java
+++ b/DynamicAnalyzer/src/utils/visitor/ExternalClasses.java
@@ -32,7 +32,7 @@ public class ExternalClasses {
 		methodMap.put("<java.lang.String: java.lang.String "
 				+ "substring(int,int)>", new JoinLevels());
 		
-		// Methods where the argument cannot have a High argument
+		// Methods where the argument cannot have a Medium argument
 		methodMap.put("<java.io.PrintStream: void println(java.lang.String)>", 
 				 new NotAllowedForPrintOutput("MEDIUM"));
 		methodMap.put("<java.io.PrintStream: void println(int)>", 
@@ -42,7 +42,15 @@ public class ExternalClasses {
 		methodMap.put("<java.io.PrintStream: void println(java.lang.Object)>", 
 				 new NotAllowedForPrintOutput("MEDIUM"));
 		
-		// Methods 
+		// Methods where the argument cannot have a High argument (but may very well have a medium argument!)
+		methodMap.put("<utils.printer.SecurePrinter: void printMedium(java.lang.Object)>", 
+				 new NotAllowedForPrintOutput("HIGH"));
+		methodMap.put("<utils.printer.SecurePrinter: void printMedium(java.lang.int)>", 
+				 new NotAllowedForPrintOutput("HIGH"));
+		methodMap.put("<utils.printer.SecurePrinter: void printMedium(java.lang.String)>", 
+				 new NotAllowedForPrintOutput("HIGH"));
+		methodMap.put("<utils.printer.SecurePrinter: void printMedium(boolean)>", 
+				 new NotAllowedForPrintOutput("HIGH"));
 		
 		// Methods where we don't do anything
 		methodMap.put("<java.lang.Object: void <init>()>", new DoNothing());

--- a/DynamicAnalyzer/src/utils/visitor/ExternalClasses.java
+++ b/DynamicAnalyzer/src/utils/visitor/ExternalClasses.java
@@ -80,7 +80,7 @@ public class ExternalClasses {
 			}
 			
 			// If print Statement is called, context must not be high: This, we can always check
-			JimpleInjector.checkThatPCNotHigh(pos);
+			JimpleInjector.checkThatPCLessThan("HIGH", pos);
 			
 			// Also, we might print in low context: If so, we mustn't print a high-sec param
 			for (Local param: params) {

--- a/DynamicAnalyzer/src/utils/visitor/ExternalClasses.java
+++ b/DynamicAnalyzer/src/utils/visitor/ExternalClasses.java
@@ -85,7 +85,7 @@ public class ExternalClasses {
 			// Also, we might print in low context: If so, we mustn't print a high-sec param
 			for (Local param: params) {
 				if (param != null) {
-					JimpleInjector.checkThatNotHigh(pos, param);
+					JimpleInjector.checkThatNot(param, "HIGH", pos);
 					
 				}
 			} 

--- a/DynamicAnalyzer/tests/CommandLineArgsTest/CmdArgsTest.java
+++ b/DynamicAnalyzer/tests/CommandLineArgsTest/CmdArgsTest.java
@@ -131,21 +131,19 @@ public class CmdArgsTest {
 		assertTrue(addFile2.exists());
 		
 		// now run it and check wheter or not it produces an IllegalFlowException
-		// Run a java app in a separate system process
 		System.out.println("Running " + outJar.toString() + "...");
 		Process proc;
 		try {
 			proc = Runtime.getRuntime().exec("java -jar " + outJar.toString());
-			// Then retreive the process output
-			InputStream err = proc.getErrorStream();
-			String output = convertStreamToString(err);
+			String output = convertStreamToString(proc.getErrorStream());
 			System.out.println(output);
 			if (hasIllegalFlow) {
 				assertTrue(output.contains("utils.exceptions.IllegalFlowException"));
 			} else {
-				assertTrue(!err.toString().contains("IllegalFlowException"));
+				assertTrue(!output.contains("utils.exceptions.IllegalFlowException"));
 			}
 		} catch (IOException e) {
+			System.out.println(e.toString());
 			assertTrue(false);
 		}
 		
@@ -161,7 +159,7 @@ public class CmdArgsTest {
 		assertTrue(!addFile2.exists());
 	}
 	
-	static String convertStreamToString(java.io.InputStream is) {
+	private static String convertStreamToString(java.io.InputStream is) {
 	    java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
 	    String ret = s.hasNext() ? s.next() : "";
 	    s.close();

--- a/DynamicAnalyzer/tests/analyzer/level2/AssignLocalsSuccess.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/AssignLocalsSuccess.java
@@ -39,11 +39,11 @@ public class AssignLocalsSuccess {
 		// hs.checkLocalPC("int_x");
 		assertEquals(SecurityLevel.bottom(), hs.setLevelOfLocal("int_x")); 
 		
-		hs.makeLocalHigh("int_x");
+		hs.makeLocal("int_x", null);
 		// x = HIGH, lpc = LOW
 		assertEquals(SecurityLevel.bottom(), hs.setLevelOfLocal("int_x")); 
 		
-		hs.makeLocalHigh("int_x");
+		hs.makeLocal("int_x", null);
 		hs.pushLocalPC(SecurityLevel.top(), 123);
 		//x = HIGH,lpc = HIGH
 		assertEquals(SecurityLevel.top(), hs.setLevelOfLocal("int_x")); 
@@ -80,7 +80,7 @@ public class AssignLocalsSuccess {
 		assertEquals(SecurityLevel.top(), hs.joinLevelOfLocalAndAssignmentLevel("int_z"));
 		assertEquals(SecurityLevel.top(), hs.setLevelOfLocal("int_x"));
 		
-		hs.makeLocalLow("int_z");
+		hs.makeLocal("int_z", "LOW");
 		// x = HIGH, lpc = LOW
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("int_x"));
 		assertEquals(SecurityLevel.bottom(), hs.getLocalLevel("int_y"));
@@ -91,7 +91,7 @@ public class AssignLocalsSuccess {
 		assertEquals(SecurityLevel.bottom(), hs.setLevelOfLocal("int_x"));
 		
 		hs.pushLocalPC(SecurityLevel.top(), 123);
-		hs.makeLocalHigh("int_x");
+		hs.makeLocal("int_x", null);
 		// x = HIGH, lpc = HIGH
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("int_x"));
 		assertEquals(SecurityLevel.bottom(), hs.getLocalLevel("int_y"));
@@ -132,7 +132,7 @@ public class AssignLocalsSuccess {
 		assertEquals(SecurityLevel.bottom(), hs.setLevelOfLocal("String_local"));
 		
 		// local = HIGH, lpc = LOW, field = LOW
-		hs.makeLocalHigh("String_local");
+		hs.makeLocal("String_local", null);
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("String_local"));
 		assertEquals(SecurityLevel.bottom(), hs.getFieldLevel(this, "String_field"));
 		assertEquals(SecurityLevel.bottom(), hs.getLocalPC());

--- a/DynamicAnalyzer/tests/analyzer/level2/AssignLocalsSuccess.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/AssignLocalsSuccess.java
@@ -39,11 +39,11 @@ public class AssignLocalsSuccess {
 		// hs.checkLocalPC("int_x");
 		assertEquals(SecurityLevel.bottom(), hs.setLevelOfLocal("int_x")); 
 		
-		hs.makeLocal("int_x", null);
+		hs.makeLocal("int_x", "HIGH");
 		// x = HIGH, lpc = LOW
 		assertEquals(SecurityLevel.bottom(), hs.setLevelOfLocal("int_x")); 
 		
-		hs.makeLocal("int_x", null);
+		hs.makeLocal("int_x", "HIGH");
 		hs.pushLocalPC(SecurityLevel.top(), 123);
 		//x = HIGH,lpc = HIGH
 		assertEquals(SecurityLevel.top(), hs.setLevelOfLocal("int_x")); 
@@ -91,7 +91,7 @@ public class AssignLocalsSuccess {
 		assertEquals(SecurityLevel.bottom(), hs.setLevelOfLocal("int_x"));
 		
 		hs.pushLocalPC(SecurityLevel.top(), 123);
-		hs.makeLocal("int_x", null);
+		hs.makeLocal("int_x", "HIGH");
 		// x = HIGH, lpc = HIGH
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("int_x"));
 		assertEquals(SecurityLevel.bottom(), hs.getLocalLevel("int_y"));
@@ -132,7 +132,7 @@ public class AssignLocalsSuccess {
 		assertEquals(SecurityLevel.bottom(), hs.setLevelOfLocal("String_local"));
 		
 		// local = HIGH, lpc = LOW, field = LOW
-		hs.makeLocal("String_local", null);
+		hs.makeLocal("String_local", "HIGH");
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("String_local"));
 		assertEquals(SecurityLevel.bottom(), hs.getFieldLevel(this, "String_field"));
 		assertEquals(SecurityLevel.bottom(), hs.getLocalPC());

--- a/DynamicAnalyzer/tests/analyzer/level2/CheckThatNotHigh.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/CheckThatNotHigh.java
@@ -28,7 +28,7 @@ public class CheckThatNotHigh {
 		
 		hs.addLocal("String_low");
 		
-		hs.checkThatNotHigh("String_low");
+		hs.checkThatNot("String_low", "HIGH");
 		
 		hs.close();
 		
@@ -49,7 +49,7 @@ public class CheckThatNotHigh {
 		
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("String_high"));
 		
-		hs.checkThatNotHigh("String_high");
+		hs.checkThatNot("String_high", "HIGH");
 		
 		hs.close();
 		

--- a/DynamicAnalyzer/tests/analyzer/level2/ForStmtFail.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/ForStmtFail.java
@@ -29,7 +29,7 @@ public class ForStmtFail {
 		
 		HandleStmt hs = new HandleStmt();
 		hs.addLocal("int_i");
-		hs.makeLocal("int_i", null);
+		hs.makeLocal("int_i", "HIGH");
 		hs.addLocal("int_res");
 		
 		int res = 0;
@@ -60,7 +60,7 @@ public class ForStmtFail {
 		
 		HandleStmt hs = new HandleStmt();
 		hs.addLocal("int_i");
-		hs.makeLocal("int_i", null);
+		hs.makeLocal("int_i","HIGH");
 		hs.addLocal("int_res");
 		
 		int res = 0;
@@ -91,7 +91,7 @@ public class ForStmtFail {
 		HandleStmt hs = new HandleStmt();
 		hs.addObjectToObjectMap(this);
 		hs.addLocal("int_i");
-		hs.makeLocal("int_i", null);
+		hs.makeLocal("int_i", "HIGH");
 		hs.addFieldToObjectMap(this, "int_res");
 		
 		int i = 0; // Local

--- a/DynamicAnalyzer/tests/analyzer/level2/ForStmtFail.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/ForStmtFail.java
@@ -29,7 +29,7 @@ public class ForStmtFail {
 		
 		HandleStmt hs = new HandleStmt();
 		hs.addLocal("int_i");
-		hs.makeLocalHigh("int_i");
+		hs.makeLocal("int_i", null);
 		hs.addLocal("int_res");
 		
 		int res = 0;
@@ -60,7 +60,7 @@ public class ForStmtFail {
 		
 		HandleStmt hs = new HandleStmt();
 		hs.addLocal("int_i");
-		hs.makeLocalHigh("int_i");
+		hs.makeLocal("int_i", null);
 		hs.addLocal("int_res");
 		
 		int res = 0;
@@ -91,7 +91,7 @@ public class ForStmtFail {
 		HandleStmt hs = new HandleStmt();
 		hs.addObjectToObjectMap(this);
 		hs.addLocal("int_i");
-		hs.makeLocalHigh("int_i");
+		hs.makeLocal("int_i", null);
 		hs.addFieldToObjectMap(this, "int_res");
 		
 		int i = 0; // Local

--- a/DynamicAnalyzer/tests/analyzer/level2/IfStmtFail.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/IfStmtFail.java
@@ -28,7 +28,7 @@ public class IfStmtFail {
 		hs.checkLocalPC("int_x");
 		hs.setLevelOfLocal("int_x");
 		int x = 1;
-		hs.makeLocalHigh("int_x");
+		hs.makeLocal("int_x", null);
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("int_x"));
 		
 		hs.addLocal("int_y");

--- a/DynamicAnalyzer/tests/analyzer/level2/IfStmtFail.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/IfStmtFail.java
@@ -28,7 +28,7 @@ public class IfStmtFail {
 		hs.checkLocalPC("int_x");
 		hs.setLevelOfLocal("int_x");
 		int x = 1;
-		hs.makeLocal("int_x", null);
+		hs.makeLocal("int_x", "HIGH");
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("int_x"));
 		
 		hs.addLocal("int_y");

--- a/DynamicAnalyzer/tests/analyzer/level2/IfStmtSuccess.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/IfStmtSuccess.java
@@ -37,7 +37,7 @@ public class IfStmtSuccess {
 			assertEquals(SecurityLevel.bottom(), hs.getLocalPC());
 			assertEquals(SecurityLevel.bottom(), hs.getGlobalPC());	
 			
-			hs.makeLocal("int_x", null);
+			hs.makeLocal("int_x", "HIGH");
 			
 			hs.checkCondition("123", "int_x");
 			if (x == 1) {
@@ -58,7 +58,7 @@ public class IfStmtSuccess {
 		assertEquals(SecurityLevel.bottom(), hs.getLocalPC());
 		assertEquals(SecurityLevel.bottom(), hs.getGlobalPC());	
 		
-		hs.makeLocal("int_x", null);
+		hs.makeLocal("int_x", "HIGH");
 		
 		hs.checkCondition("123", "int_x");
 		if (x == 1) {

--- a/DynamicAnalyzer/tests/analyzer/level2/IfStmtSuccess.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/IfStmtSuccess.java
@@ -37,7 +37,7 @@ public class IfStmtSuccess {
 			assertEquals(SecurityLevel.bottom(), hs.getLocalPC());
 			assertEquals(SecurityLevel.bottom(), hs.getGlobalPC());	
 			
-			hs.makeLocalHigh("int_x");
+			hs.makeLocal("int_x", null);
 			
 			hs.checkCondition("123", "int_x");
 			if (x == 1) {
@@ -58,7 +58,7 @@ public class IfStmtSuccess {
 		assertEquals(SecurityLevel.bottom(), hs.getLocalPC());
 		assertEquals(SecurityLevel.bottom(), hs.getGlobalPC());	
 		
-		hs.makeLocalHigh("int_x");
+		hs.makeLocal("int_x", null);
 		
 		hs.checkCondition("123", "int_x");
 		if (x == 1) {
@@ -73,7 +73,7 @@ public class IfStmtSuccess {
 		assertEquals(SecurityLevel.bottom(), hs.getLocalPC());
 		assertEquals(SecurityLevel.bottom(), hs.getGlobalPC());	
 		
-		hs.makeLocalLow("int_x");
+		hs.makeLocal("int_x", "LOW");
 		hs.pushLocalPC(SecurityLevel.top(), 234);
 		hs.pushGlobalPC(SecurityLevel.top());
 		

--- a/DynamicAnalyzer/tests/analyzer/level2/InvokeSuccess.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/InvokeSuccess.java
@@ -93,7 +93,7 @@ public class InvokeSuccess {
 		assertEquals(SecurityLevel.bottom(), hs.getActualReturnLevel());
     	
     	
-		hs.makeLocal("int_b", null);
+		hs.makeLocal("int_b", "HIGH");
 		hs.storeArgumentLevels("int_a", "int_b", "int_c");
 		xy.methodWithParams(a, b, c);
 		assertEquals(SecurityLevel.top(), hs.getActualReturnLevel());

--- a/DynamicAnalyzer/tests/analyzer/level2/InvokeSuccess.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/InvokeSuccess.java
@@ -93,7 +93,7 @@ public class InvokeSuccess {
 		assertEquals(SecurityLevel.bottom(), hs.getActualReturnLevel());
     	
     	
-		hs.makeLocalHigh("int_b");
+		hs.makeLocal("int_b", null);
 		hs.storeArgumentLevels("int_a", "int_b", "int_c");
 		xy.methodWithParams(a, b, c);
 		assertEquals(SecurityLevel.top(), hs.getActualReturnLevel());

--- a/DynamicAnalyzer/tests/analyzer/level2/Nico.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/Nico.java
@@ -31,7 +31,7 @@ public class Nico {
 		hs.addLocal("int_y");
 		hs.setLevelOfLocal("int_y");
 		int y = 2;
-		hs.makeLocalHigh("int_y");
+		hs.makeLocal("int_y", null);
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("int_y"));
 
 		assertEquals(SecurityLevel.bottom(), hs.getLocalPC());

--- a/DynamicAnalyzer/tests/analyzer/level2/Nico.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/Nico.java
@@ -31,7 +31,7 @@ public class Nico {
 		hs.addLocal("int_y");
 		hs.setLevelOfLocal("int_y");
 		int y = 2;
-		hs.makeLocal("int_y", null);
+		hs.makeLocal("int_y", "HIGH");
 		assertEquals(SecurityLevel.top(), hs.getLocalLevel("int_y"));
 
 		assertEquals(SecurityLevel.bottom(), hs.getLocalPC());

--- a/DynamicAnalyzer/tests/analyzer/level2/storage/LowMiddleHighTest.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/storage/LowMiddleHighTest.java
@@ -25,6 +25,14 @@ public class LowMiddleHighTest {
 			assertTrue(SecurityLevel.lt(LowMediumHigh.Level.LOW, LowMediumHigh.Level.MEDIUM));
 			assertTrue(SecurityLevel.lt(LowMediumHigh.Level.LOW, LowMediumHigh.Level.HIGH));
 			assertTrue(SecurityLevel.lt(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.HIGH));
+			
+			assertTrue(!SecurityLevel.lt(LowMediumHigh.Level.LOW, LowMediumHigh.Level.LOW));
+			assertTrue(!SecurityLevel.lt(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.MEDIUM));
+			assertTrue(!SecurityLevel.lt(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.HIGH));
+			
+			assertTrue(!SecurityLevel.lt(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.LOW));
+			assertTrue(!SecurityLevel.lt(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.MEDIUM));
+			assertTrue(!SecurityLevel.lt(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.LOW));
 	}
 	
 	@Test

--- a/DynamicAnalyzer/tests/analyzer/level2/storage/LowMiddleHighTest.java
+++ b/DynamicAnalyzer/tests/analyzer/level2/storage/LowMiddleHighTest.java
@@ -1,0 +1,77 @@
+package analyzer.level2.storage;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import analyzer.level2.SecurityLevel;
+
+/**
+ * The most fun-to-write unit test in the whole project
+ * @author Nicolas Müller
+ *
+ */
+public class LowMiddleHighTest {
+	
+	@Before
+	 public void beforeMethod() {
+	     org.junit.Assume.assumeTrue(SecurityLevel.secDomain instanceof LowMediumHigh);
+	     // rest of setup.
+	 }
+	
+	@Test
+	public void LessThanTest() {
+			assertTrue(SecurityLevel.lt(LowMediumHigh.Level.LOW, LowMediumHigh.Level.MEDIUM));
+			assertTrue(SecurityLevel.lt(LowMediumHigh.Level.LOW, LowMediumHigh.Level.HIGH));
+			assertTrue(SecurityLevel.lt(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.HIGH));
+	}
+	
+	@Test
+	public void LessThanEqualTest() {
+		assertTrue(SecurityLevel.le(LowMediumHigh.Level.LOW, LowMediumHigh.Level.LOW));
+		assertTrue(SecurityLevel.le(LowMediumHigh.Level.LOW, LowMediumHigh.Level.MEDIUM));
+		assertTrue(SecurityLevel.le(LowMediumHigh.Level.LOW, LowMediumHigh.Level.HIGH));
+		assertTrue(SecurityLevel.le(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.MEDIUM));
+		assertTrue(SecurityLevel.le(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.HIGH));
+		assertTrue(SecurityLevel.le(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.HIGH));
+	}
+	
+	@Test
+	public void GreatestLowerBound(){
+		assertTrue(SecurityLevel.glb(LowMediumHigh.Level.LOW, LowMediumHigh.Level.LOW).equals(LowMediumHigh.Level.LOW));
+		assertTrue(SecurityLevel.glb(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.LOW).equals(LowMediumHigh.Level.LOW));
+		assertTrue(SecurityLevel.glb(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.LOW).equals(LowMediumHigh.Level.LOW));
+		
+		assertTrue(SecurityLevel.glb(LowMediumHigh.Level.LOW, LowMediumHigh.Level.MEDIUM).equals(LowMediumHigh.Level.LOW));
+		assertTrue(SecurityLevel.glb(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.MEDIUM).equals(LowMediumHigh.Level.MEDIUM));
+		assertTrue(SecurityLevel.glb(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.MEDIUM).equals(LowMediumHigh.Level.MEDIUM));
+		
+		assertTrue(SecurityLevel.glb(LowMediumHigh.Level.LOW, LowMediumHigh.Level.HIGH).equals(LowMediumHigh.Level.LOW));
+		assertTrue(SecurityLevel.glb(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.HIGH).equals(LowMediumHigh.Level.MEDIUM));
+		assertTrue(SecurityLevel.glb(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.HIGH).equals(LowMediumHigh.Level.HIGH));
+	}
+	
+	@Test
+	public void LeastUpperBound() {
+		assertTrue(SecurityLevel.lub(LowMediumHigh.Level.LOW, LowMediumHigh.Level.LOW).equals(LowMediumHigh.Level.LOW));
+		assertTrue(SecurityLevel.lub(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.LOW).equals(LowMediumHigh.Level.MEDIUM));
+		assertTrue(SecurityLevel.lub(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.LOW).equals(LowMediumHigh.Level.HIGH));
+
+		assertTrue(SecurityLevel.lub(LowMediumHigh.Level.LOW, LowMediumHigh.Level.MEDIUM).equals(LowMediumHigh.Level.MEDIUM));
+		assertTrue(SecurityLevel.lub(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.MEDIUM).equals(LowMediumHigh.Level.MEDIUM));
+		assertTrue(SecurityLevel.lub(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.MEDIUM).equals(LowMediumHigh.Level.HIGH));
+
+		assertTrue(SecurityLevel.lub(LowMediumHigh.Level.LOW, LowMediumHigh.Level.HIGH).equals(LowMediumHigh.Level.HIGH));
+		assertTrue(SecurityLevel.lub(LowMediumHigh.Level.MEDIUM, LowMediumHigh.Level.HIGH).equals(LowMediumHigh.Level.HIGH));
+		assertTrue(SecurityLevel.lub(LowMediumHigh.Level.HIGH, LowMediumHigh.Level.HIGH).equals(LowMediumHigh.Level.HIGH));
+	}
+	
+	@Test
+	public void parserTest() {
+		assertTrue(SecurityLevel.readLevel("HIGH").equals(LowMediumHigh.Level.HIGH));
+		assertTrue(SecurityLevel.readLevel("MEDIUM").equals(LowMediumHigh.Level.MEDIUM));
+		assertTrue(SecurityLevel.readLevel("LOW").equals(LowMediumHigh.Level.LOW));
+	}
+
+}

--- a/DynamicAnalyzer/tests/end2endtest/AllEndToEndTests.java
+++ b/DynamicAnalyzer/tests/end2endtest/AllEndToEndTests.java
@@ -124,6 +124,7 @@ public class AllEndToEndTests {
 				// Acting with Mediums!
 				new Object[] { "PrintMediumSuccess", false, new String[] {} }, 
 				new Object[] { "PrintMediumFail", true, new String[] {"java.lang.String_r3"} }, 
+				new Object[] { "PrintMediumFail2", true, new String[] {"java.lang.String_r3"} }, 
 				
 				// SystemOut1 and SystemOut2 are nearly the same! but behave differently!!
 				new Object[] { "SystemOut1", true, new String[] {"int_i0"} },

--- a/DynamicAnalyzer/tests/end2endtest/AllEndToEndTests.java
+++ b/DynamicAnalyzer/tests/end2endtest/AllEndToEndTests.java
@@ -121,6 +121,10 @@ public class AllEndToEndTests {
 				
 				new Object[] { "PrivateVariableSuccess", false, new String[] {} }, 
 				
+				// Acting with Mediums!
+				new Object[] { "PrintMediumSuccess", false, new String[] {} }, 
+				new Object[] { "PrintMediumFail", true, new String[] {"java.lang.String_r3"} }, 
+				
 				// SystemOut1 and SystemOut2 are nearly the same! but behave differently!!
 				new Object[] { "SystemOut1", true, new String[] {"int_i0"} },
 				new Object[] { "SystemOut2", true, new String[] {"java.lang.Object_$r3"} },						

--- a/DynamicAnalyzer/tests/end2endtest/SingleEndToEndTest.java
+++ b/DynamicAnalyzer/tests/end2endtest/SingleEndToEndTest.java
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
  */
 public class SingleEndToEndTest {
 
-	public String name = "NewClassFail1";
+	public String name = "ImplicitFlow2";
 
 	public boolean hasIllegalFlow = true;
 

--- a/DynamicAnalyzer/tests/end2endtest/SingleEndToEndTest.java
+++ b/DynamicAnalyzer/tests/end2endtest/SingleEndToEndTest.java
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
  */
 public class SingleEndToEndTest {
 
-	public String name = "ImplicitFlow2";
+	public String name = "PrintMediumSuccess";
 
 	public boolean hasIllegalFlow = true;
 

--- a/DynamicAnalyzer/tests/end2endtest/SingleEndToEndTest.java
+++ b/DynamicAnalyzer/tests/end2endtest/SingleEndToEndTest.java
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
  */
 public class SingleEndToEndTest {
 
-	public String name = "PrintMediumSuccess";
+	public String name = "PrintMediumFail2";
 
 	public boolean hasIllegalFlow = true;
 

--- a/DynamicAnalyzer/tests/testmain/RunAllTests.java
+++ b/DynamicAnalyzer/tests/testmain/RunAllTests.java
@@ -23,6 +23,7 @@ import analyzer.level2.SwitchStmtSuccess;
 import analyzer.level2.WhileStmtFail;
 import analyzer.level2.WhileStmtSuccess;
 import analyzer.level2.storage.LocalMapTest;
+import analyzer.level2.storage.LowMiddleHighTest;
 import analyzer.level2.storage.ObjectMapTest;
 import analyzer.level2.storage.SecurityOptionalTest;
 
@@ -72,6 +73,9 @@ import end2endtest.SingleEndToEndTest;
     
     // Test for commandline arguments and correct path output
     CmdArgsTest.class,
+    
+    // Tests for LowMiddleHigh Lattice
+    LowMiddleHighTest.class,
 
     // Tests for valid bytecode of testclasses
     AllEndToEndTests.class,

--- a/DynamicAnalyzer/tests/tests/testclasses/TestClass.java
+++ b/DynamicAnalyzer/tests/tests/testclasses/TestClass.java
@@ -53,7 +53,7 @@ public class TestClass {
     	
     	int a2 = 23;
     	
-    	hs.makeLocalHigh("int_a2");
+    	hs.makeLocal("int_a2", null);
     	hs.joinLevelOfLocalAndAssignmentLevel("int_a1");
     	hs.joinLevelOfLocalAndAssignmentLevel("int_a2");
     	hs.setLevelOfLocal("int_res");

--- a/DynamicAnalyzer/tests/tests/testclasses/TestSubClass.java
+++ b/DynamicAnalyzer/tests/tests/testclasses/TestSubClass.java
@@ -87,7 +87,7 @@ public class TestSubClass {
 		
 		hs.setLevelOfLocal("int_result");
 		int result = 0;
-		hs.makeLocalHigh("int_result");
+		hs.makeLocal("int_result", null);
 		
 		hs.returnLocal("int_result");
 		hs.close();

--- a/DynamicAnalyzer/tests/tests/testclasses/TestSubClass.java
+++ b/DynamicAnalyzer/tests/tests/testclasses/TestSubClass.java
@@ -87,7 +87,7 @@ public class TestSubClass {
 		
 		hs.setLevelOfLocal("int_result");
 		int result = 0;
-		hs.makeLocal("int_result", null);
+		hs.makeLocal("int_result", "HIGH");
 		
 		hs.returnLocal("int_result");
 		hs.close();


### PR DESCRIPTION
Hey Lu,

es hat alles geklappt (bzw. alle Probleme hab ich selber gelöst bekommen). Ich habe jetzt Folgendes erledigt:
- `checkThatPCNotHigh(String signatur)` zu `checkThatPCNot(String signature, String Level)` umgeschrieben (v.a. im `HandleStatement` und `JimpleInjector`), analog andere methoden wie `checkThatLocalNotHigh`
- einen `LowMiddleHigh` Security Lattice implementiert
- der ist jetzt auch scharf geschalten, und alles bisherige funktioniert
- Medium geht auch: `SecurePrinter.printMedium(T out)` tut was es soll
- es ist alles getestet in `LowMiddleHighTest` und `PrintMedium{Success, Fail1, Fail2}`.

Passt das soweit?
Liebe Grüße,
Nico

ps.: `makeFieldHigh` und `makeFieldLow` werden nie im Code (auch nicht im `JimpleInjector`) verwendet (ausser direkt in den Instrumentierten Tests… können die raus?)